### PR TITLE
updated egg version to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egg = "0.6.0"
+egg = {version = "0.7.1", features = ["serde-1"]}
 log = "0.4.0"
 env_logger = "0.8.4"
 chrono = "0.4"
-serde_json = "1.0"
+serde_json = "1"
 clap = "3.0.0-beta.5"
 symbolic_expressions = "5"
 nix = "0.23.0"
-serde = "1.0.130"
+serde = "1"
 procspawn = "0.10.0"
 lazy_static = "1.4.0"
 sexp = "1.1.4"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -636,7 +636,8 @@ pub struct LambdaAnalysis;
 
 impl Analysis<Lambda> for LambdaAnalysis {
     type Data = Data;
-    fn merge(&self, to: &mut Data, from: Data) -> bool {
+    // fn merge(&self, to: &mut Self::Data, from: Self::Data) -> bool;
+    fn merge(&mut self, to: &mut Data, from: Data) -> egg::DidMerge {
         // we really shouldnt be merging anyone ever rn I think.
         panic!("shouldn't be merging");
 
@@ -647,7 +648,7 @@ impl Analysis<Lambda> for LambdaAnalysis {
         // keep the lowest inventionless cost
         // modified |= merge_inventionless(&mut to.inventionless_cost_any, &from.inventionless_cost_any);
         
-        false // didnt modify anything
+        DidMerge(false,false) // didnt modify anything
     }
 
     fn make(egraph: &EGraph, enode: &Lambda) -> Data {
@@ -1423,7 +1424,7 @@ fn compression_step(
 
     // print out the largest variable we've seen (useful to make sure our egraph isnt exploding due to Vars)
     for i in 0..1000 {
-        if search(format!("(${})",i).as_str(),&egraph).is_empty() {
+        if format!("(${})",i).parse::<Pattern<Lambda>>().unwrap().search(&egraph).is_empty() {
             println!("Largest variable: ${}",i-1);
             break;
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use sexp::{Sexp,Atom};
-use std::fmt::Debug;
+use std::fmt::{Debug,Display};
 
 /// Uncurries an s expression. For example: (app (app foo x) y) -> (foo x y)
 /// panics if sexp is already uncurried.
@@ -97,18 +97,18 @@ pub fn timestamp() -> String {
     format!("{}", chrono::Local::now().format("%Y-%m-%d_%H-%M-%S"))
 }
 
-pub fn search<L,A>(pat: &str, egraph: &EGraph<L,A>) -> Vec<SearchMatches>
-where 
-    L: Language,
-    A: Analysis<L>
-{
-    let applam:Pattern<L> = pat.parse().unwrap();
-    applam.search(&egraph)
-}
+// pub fn search<'a,L,A>(pat: &str, egraph: &EGraph<L,A>) -> Vec<SearchMatches<'a,L>>
+// where 
+//     L: Language + FromOp,
+//     A: Analysis<L>
+// {
+//     let applam:Pattern<L> = pat.parse().unwrap();
+//     applam.search(&egraph)
+// }
 
 pub fn save<L,A>(egraph: &EGraph<L,A>, name: &str, outdir: &str) 
 where 
-    L: Language,
+    L: Language + Display,
     A: Analysis<L>
 {
     egraph.dot().to_png(format!("{}/{}.png",outdir,name)).unwrap();


### PR DESCRIPTION
changes:
- trivial switch to `impl FromOp for Lambda`
- switch to DidMerge
- fixed various little errors based on signature changes in the version change

quick check to make sure things still work: slowed down 30%. Not a huge deal given our current goals, we'll optimize things later when we care about it and some of these slowdowns be `egg` specific things we can't touch.
```
Command: cargo run --bin=compress --release -- -f data/train_200.json --max-arity=2 --iterations=1

New:
Final egraph: 3578949 nodes, 3578949 classes, 3578949 memo
Largest variable: $1
Cands useful at top level: 203382
Core stuff took: 20319ms ***
Expected cost: 400332
new rewriter cost: 394660

Old:
Final egraph: 3578949 nodes, 3578949 classes, 3578949 memo
Largest variable: $1
Cands useful at top level: 203382
Core stuff took: 15733ms ***
Expected cost: 400332
new rewriter cost: 394660
```